### PR TITLE
Issues/issue1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # version
 
-- 1.0.0
+- 1.1.0
 
 # config
 
@@ -63,37 +63,8 @@
 
 ## package installed
 
-- "autoprefixer": "^6.3.4",
-- "babel-preset-es2015": "^6.6.0",
-- "babelify": "^7.2.0",
-- "browser-sync": "^2.11.2",
-- "cssnano": "^3.5.2",
-- "del": "^1.2.1",
-- "es6-promise": "3.1.2",
-- "eslint-config-gnavi": "0.0.9",
-- "gulp": "^3.9.1",
-- "gulp-babel": "^6.1.1",
-- "gulp-browserify": "^0.5.1",
-- "gulp-concat": "^2.6.0",
-- "gulp-concat-util": "^0.5.5",
-- "gulp-ejs": "^2.1.1",
-- "gulp-htmlmin": "^1.3.0",
-- "gulp-imageoptim": "^1.0.3",
-- "gulp-jshint": "^2.0.0",
-- "gulp-minify-ejs": "^1.0.3",
-- "gulp-plumber": "^1.0.1",
-- "gulp-postcss": "^6.1.0",
-- "gulp-rename": "^1.2.2",
-- "gulp-sequence": "^0.4.4",
-- "gulp-size": "^2.0.0",
-- "gulp-styledocco": "0.0.3",
-- "gulp-stylestats": "^1.1.0",
-- "gulp-uglify": "^1.5.1",
-- "gulp-util": "^3.0.6",
-- "gulp-watch": "^4.3.5",
-- "gulp.spritesmith": "^6.2.0",
-- "jshint": "^2.8.0",
-- "precss": "^1.4.0"
+package.json参照
+
 
 # ルートディレクトリ構成
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,11 +104,13 @@ gulp.task('imageOptim', function() {
  */
 // precss(scss like)
 var precss = require('precss');
+var clearfix = require('postcss-clearfix');
 gulp.task('sass', function () {
   return gulp.src(path.css_src + '**/*.css')
     .pipe(plumber())
     .pipe(postcss([
-        precss()
+        precss(),
+        clearfix()
     ]))
     .pipe(gulp.dest(path.tmp + 'css/'));
  });
@@ -193,11 +195,10 @@ gulp.task('jshint', function () {
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });
+var eslint = require('gulp-eslint');
 gulp.task('eslint', function () {
   return gulp.src(path.js_src + 'all/*.js')
-    .pipe(plumber())
-    .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(eslint('eslint-config-gnavi'));
 });
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,15 +77,11 @@ gulp.task('sprite', function () {
     imgPath: '../img/sprite-sample.png',
     cssFormat: 'css',
     padding: 5,
-    cssOpts: {
-    cssSelector: function (sprite) {
-      return '@define-extend icon--' + sprite.name;
-    }
-  }
   }));
   spriteData.img.pipe(gulp.dest(path.img_src));
-  spriteData.css.pipe(gulp.dest(path.css_src + 'all/module/'))
-    .pipe(size({title:'size : sprite'}));
+  spriteData.css
+  .pipe(gulp.dest(path.css_src + 'all/module/'))
+  .pipe(size({title:'size : sprite'}));
 });
 
 /*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -286,7 +286,7 @@ gulp.task('build:css', function () {
 
 // build:js
 gulp.task('build:js', function () {
-  gulpSequence('concat', 'uglify', 'jshint')();
+  gulpSequence('test', 'concat', 'uglify')();
 });
 gulp.task('concat', function () {
   gulpSequence('concat:lib', 'concat:common')();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "",
   "description": "gulp boilerplate for gnavi front-end development",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "homepage": "",
   "main": "index",
   "scripts": {
@@ -9,18 +9,14 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "del": "^2.2.0",
-    "gulp": "~3.9.0",
-    "time-require": "^0.1.2"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "autoprefixer": "^6.3.4",
+    "autoprefixer": "^6.3.7",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browser-sync": "^2.11.2",
     "cssnano": "^3.5.2",
-    "del": "^1.2.1",
+    "del": "^2.2.1",
     "es6-promise": "3.1.2",
     "eslint-config-gnavi": "0.0.9",
     "gulp": "^3.9.1",
@@ -28,7 +24,8 @@
     "gulp-browserify": "^0.5.1",
     "gulp-concat": "^2.6.0",
     "gulp-concat-util": "^0.5.5",
-    "gulp-ejs": "^2.1.1",
+    "gulp-ejs": "^2.1.2",
+    "gulp-eslint": "^3.0.1",
     "gulp-htmlmin": "^1.3.0",
     "gulp-imageoptim": "^1.0.3",
     "gulp-jshint": "^2.0.0",
@@ -44,8 +41,11 @@
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.5",
     "gulp.spritesmith": "^6.2.0",
-    "jshint": "^2.8.0",
-    "precss": "^1.4.0"
+    "momentjs": "^1.1.12",
+    "postcss-clearfix": "^1.0.0",
+    "postcss-extend": "^1.0.4",
+    "precss": "^1.4.0",
+    "time-require": "^0.1.2"
   },
   "repository": {},
   "keywords": [],

--- a/src/css/all/module/content.css
+++ b/src/css/all/module/content.css
@@ -22,13 +22,13 @@
 }
 .icon--c {
   display: flex;
-  @extend icon--c;
+  @include sprite($icon-c);
 }
 .icon--a {
   display: flex;
-  @extend icon--a;
+  @include sprite($icon-a);
 }
 .icon--b {
   display: flex;
-  @extend icon--b;
+  @include sprite($icon-b);
 }

--- a/src/css/all/module/sprite-sample.css
+++ b/src/css/all/module/sprite-sample.css
@@ -1,39 +1,46 @@
 /*
 Icon classes can be used entirely standalone. They are named after their original file names.
 
-```html
-<!-- `display: block` sprite -->
+Example usage in HTML:
+
+`display: block` sprite:
 <div class="icon-home"></div>
 
-<!-- `display: inline-block` sprite -->
-<img class="icon-home" />
-```
+To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+
+// CSS
+.icon {
+  display: inline-block;
+}
+
+// HTML
+<i class="icon icon-home"></i>
 */
-@define-extend icon--a {
+.icon-a {
   background-image: url(../img/sprite-sample.png);
   background-position: -66px 0px;
   width: 38px;
   height: 49px;
 }
-@define-extend icon--b {
+.icon-b {
   background-image: url(../img/sprite-sample.png);
   background-position: -109px 0px;
   width: 30px;
   height: 32px;
 }
-@define-extend icon--c {
+.icon-c {
   background-image: url(../img/sprite-sample.png);
   background-position: -66px -54px;
   width: 32px;
   height: 53px;
 }
-@define-extend icon--n4 {
+.icon-n4 {
   background-image: url(../img/sprite-sample.png);
   background-position: 0px 0px;
   width: 61px;
   height: 59px;
 }
-@define-extend icon--n5 {
+.icon-n5 {
   background-image: url(../img/sprite-sample.png);
   background-position: 0px -64px;
   width: 54px;


### PR DESCRIPTION
## ブラッシュアップもろもろ
- version no. 更新
- パッケージリストをdevDependencies内に集約、一覧性を保つ
- 未使用のパッケージを削除
- 一部パッケージのマイナーバージョンアップ
- momentjs、postcss-clearfix、postcss-extendの追加
- READMEのpackageリストを「package.json参照」の文言に変更
- gulp-eslint部分でeslint部分のタスク修正
- postcss-clearfixのタスク追加
- sprite周りのコードをpostcss-extendに対応、エラー解消
