### PR TITLE
cssnanoのオプションを追加

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,11 @@ gulp.task('renamecss', function () {
       browsers: ['last 2 version', 'ie >= 9'],
       cascade: false
      }),
-    cssnano()
+    cssnano({
+      minifyFontValues: {
+        removeQuotes: false
+      }
+    })
   ]))
   .pipe(gulp.dest(path.dist + 'css/'))
   .pipe(size({title:'size : css'}));


### PR DESCRIPTION
CSS圧縮時にfont-familyのクオートまで削られるので、一部ブラウザで意図したフォントが当たらない問題を修正しました。