### PR TITLE
ESLint ルール適用

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+bin
+dist
+src/js/lib
+gulpfile.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "extends": ["eslint-config-gnavi/legacy"],
+  "env": {
+    "browser": true,
+    "node": false
+  },
+  "globals": {
+    "PROJECTNAMESPACE": true,
+    "_": true,
+    "$": true,
+    "jQuery": true
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /**
- * gulp-boiler
+ * gnavi-gulp-boiler-ejs-postcss
  *
  * ** 開発開始手順
  *
@@ -19,7 +19,7 @@
  *
  * $ gulp optim
  *
- * ** jshintコマンド
+ * ** eslintコマンド
  *
  * $ gulp test
  *
@@ -189,19 +189,14 @@ gulp.task('uglify', function () {
     .pipe(size({title:'size : js'}));
 });
 
-// jshint
-var jshint = require('gulp-jshint');
-gulp.task('jshint', function () {
-  return gulp.src(path.js_src + 'all/*.js')
-    .pipe(plumber())
-    .pipe(jshint())
-    .pipe(jshint.reporter('default'));
-});
+// eslint
+var eslint = require('gulp-eslint');
 gulp.task('eslint', function () {
   return gulp.src(path.js_src + 'all/*.js')
     .pipe(plumber())
-    .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(eslint())
+    .pipe(eslint.format())
+    .pipe(eslint.failOnError())
 });
 
 
@@ -257,7 +252,6 @@ gulp.task('copy', function () {
  */
 var browserSync = require('browser-sync');
 gulp.task('serve', function () {
-  gulpSequence('build')();
   browserSync({
     notify: false,
     server: {
@@ -293,7 +287,7 @@ gulp.task('build:css', function () {
 
 // build:js
 gulp.task('build:js', function () {
-  gulpSequence('concat', 'uglify', 'jshint')();
+  gulpSequence('concat', 'uglify', 'eslint')();
 });
 gulp.task('concat', function () {
   gulpSequence('concat:lib', 'concat:common')();
@@ -316,7 +310,7 @@ gulp.task('optim', function () {
 
 // test
 gulp.task('test', function () {
-  gulpSequence('jshint', 'eslint')();
+  gulpSequence('eslint')();
 });
 
 // build

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "",
+  "name": "gnavi-gulp-boiler-ejs-postcss",
   "description": "gulp boilerplate for gnavi front-end development",
   "version": "1.0.4",
   "homepage": "",
   "main": "index",
   "scripts": {
+    "start": "gulp start",
+    "build": "gulp build",
+    "sprite": "gulp sprite",
+    "optim": "gulp optim",
+    "test": "gulp test",
     "stats": "./node_modules/stylestats/bin/cli.js dist/css/*.css -f csv > stats.csv"
   },
   "author": "",
@@ -22,16 +27,16 @@
     "cssnano": "^3.5.2",
     "del": "^1.2.1",
     "es6-promise": "3.1.2",
-    "eslint-config-gnavi": "0.0.9",
+    "eslint-config-gnavi": "^1.0.0-beta1",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.1",
     "gulp-browserify": "^0.5.1",
     "gulp-concat": "^2.6.0",
     "gulp-concat-util": "^0.5.5",
     "gulp-ejs": "^2.1.1",
+    "gulp-eslint": "^3.0.1",
     "gulp-htmlmin": "^1.3.0",
     "gulp-imageoptim": "^1.0.3",
-    "gulp-jshint": "^2.0.0",
     "gulp-minify-ejs": "^1.0.3",
     "gulp-plumber": "^1.0.1",
     "gulp-postcss": "^6.1.0",
@@ -44,10 +49,12 @@
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.5",
     "gulp.spritesmith": "^6.2.0",
-    "jshint": "^2.8.0",
     "precss": "^1.4.0"
   },
-  "repository": {},
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://github.com/gurunavi-creators/gnavi-gulp-boiler-ejs-postcss.git"
+  },
   "keywords": [],
   "bugs": {}
 }

--- a/src/css/all/module/content.css
+++ b/src/css/all/module/content.css
@@ -1,3 +1,4 @@
+@import "sprite.css";
 @charset "utf-8";
 /* link-home */
 .link-home {

--- a/src/js/all/sample_a.js
+++ b/src/js/all/sample_a.js
@@ -1,50 +1,26 @@
 /**
- * grunt-boiler
+ * gnavi-gulp-boiler-ejs-postcss
  * all.js - sample_a.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
-// run
-$(function () {
-  sampleA.init();
-  sampleFunction1();
-});
+/* globals Utility */
 
 // sample A module
 var sampleA = {
-  init: function () {
-    PROJECTNAMESPACE.Utility.console('A');
+  init: function init() {
+    Utility.console('A')
   }
-};
+}
 
 // sample function
-var sampleFunction1 = function () {
-  var hoge1 = 1;
-  var huga1 = 2;
+function sampleFunction1() {
+  var hoge = '1'
+  var huga = '2'
+  return hoge + huga
+}
 
-  var hoge2 = 1;
-  var huga2 = 2;
-
-  var hoge3 = 1;
-  var huga3 = 2;
-
-  var hoge4 = 1;
-  var huga4 = 2;
-
-  var hoge5 = 1;
-  var huga5 = 2;
-
-  var hoge6 = 1;
-  var huga6 = 2;
-
-  var hoge7 = 1;
-  var huga7 = 2;
-
-  var hoge8 = 1;
-  var huga8 = 2;
-
-  var hoge9 = 1;
-  var huga9 = 2;
-
-  var hoge10 = 1;
-  var huga10 = 2;
-};
+// run
+$(function run() {
+  sampleA.init()
+  sampleFunction1()
+})

--- a/src/js/all/sample_b.js
+++ b/src/js/all/sample_b.js
@@ -1,50 +1,26 @@
 /**
- * grunt-boiler
+ * gnavi-gulp-boiler-ejs-postcss
  * all.js - sample_b.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
-// run
-$(function () {
-  sampleB.init();
-  sampleFunction2();
-});
+/* globals Utility */
 
 // sample B module
 var sampleB = {
-  init: function () {
-    PROJECTNAMESPACE.Utility.console('B');
+  init: function init() {
+    Utility.console('B')
   }
-};
+}
 
 // sample function
-var sampleFunction2 = function () {
-  var hoge1 = 1;
-  var huga1 = 2;
+function sampleFunction2() {
+  var hoge = '1'
+  var huga = '2'
+  return hoge + huga
+}
 
-  var hoge2 = 1;
-  var huga2 = 2;
-
-  var hoge3 = 1;
-  var huga3 = 2;
-
-  var hoge4 = 1;
-  var huga4 = 2;
-
-  var hoge5 = 1;
-  var huga5 = 2;
-
-  var hoge6 = 1;
-  var huga6 = 2;
-
-  var hoge7 = 1;
-  var huga7 = 2;
-
-  var hoge8 = 1;
-  var huga8 = 2;
-
-  var hoge9 = 1;
-  var huga9 = 2;
-
-  var hoge10 = 1;
-  var huga10 = 2;
-};
+// run
+$(function run() {
+  sampleB.init()
+  sampleFunction2()
+})

--- a/src/js/all/utility.js
+++ b/src/js/all/utility.js
@@ -1,61 +1,26 @@
 /**
- * grunt-boiler
+ * gnavi-gulp-boiler-ejs-postcss
  * all.js - utility.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
-PROJECTNAMESPACE.Utility = {
-  console: function (value) {
-    value = value || null;
-    console.log(value);
+/* exported Utility */
+
+var Utility = {
+  console: function utilityConsole(value) {
+    var value2 = value || null
+    console.log(value2)
   },
 
-  sampleUtility1: function () {
-    var hoge = 1;
-    var huga = 2;
+  sampleUtility1: function sampleUtility1() {
+    var hoge = '1'
+    var huga = '2'
+    return hoge + huga
   },
 
-  sampleUtility2: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility3: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility4: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility5: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility6: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility7: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility8: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility9: function () {
-    var hoge = 1;
-    var huga = 2;
-  },
-
-  sampleUtility10: function () {
-    var hoge = 1;
-    var huga = 2;
+  sampleUtility2: function sampleUtility2() {
+    var hoge = '1'
+    var huga = '2'
+    return hoge + huga
   }
-};
+
+}


### PR DESCRIPTION
eslint-config-gnavi の最新ルール適用に合わせて以下修正を行なっています。
- eslint-config-gnavi を 1.0.0 beta へアップグレード
- Linter を ESLint に統合するため、 JSHint を削除
- ESLint の最新ルールで該当する `src/js` 配下のエラー修正
- package.json の不足情報補足